### PR TITLE
Read spaced path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Allows automated sorting of a given folder or folders into organised subfolders
 1. I strongly recommend running the built in tests before trying this on your personal files. To do this, navigate to auto-folder-sort and run `pyhton3 -m tests.main_test'.
    - All tests should pass with no issues. If ANY don't pass, please let me know and don't run the program on your folders as there is something wrong.
 2. To set which folders you want sorted, you must edit the folders_to_track.txt file located in the same folder as main.py.
-   - Each line will be read as 1 folder to track/sort and must have at least 2 space separated paramaeter provided
+   - Each line will be read as 1 folder to track/sort and must have at least 2 paramaters separated by the symbol "|"
    - Required parameters: Folder path and sort type (can only be 'date' or 'file_type')
    - Optional parameter: Earliest year (for date sort, folders will be generated for years ranging from this value to the current year)
 3. An example of an input file can be found in the examples folder.

--- a/auto-folder-sort/main.py
+++ b/auto-folder-sort/main.py
@@ -60,7 +60,10 @@ class Main:
 
         # Get commands from text file
         with open(COMMANDS_PATH, "r") as txt:
-            self.commands = [line.split() for line in txt.readlines()]
+            # Splits each line at '|' and strips each item of trailing whitespace
+            self.commands = [
+                list(map(str.strip, line.split("|"))) for line in txt.readlines()
+            ]
 
         logger.debug(f"Commands read from text file: {self.commands}")
 

--- a/auto-folder-sort/tests/main_test.py
+++ b/auto-folder-sort/tests/main_test.py
@@ -200,6 +200,9 @@ class TestMain(unittest.TestCase):
         self.assertFalse(self.try_command(SAMPLE_PATH_2 + " | date | 2015 | 2018"))
         self.assertFalse(self.try_command("date | file_type | string | 2018"))
         self.assertFalse(self.try_command("date | file_type | string | 2018"))
+        self.assertFalse(self.try_command(SAMPLE_PATH_2 + " date 2018"))
+        self.assertFalse(self.try_command(SAMPLE_PATH_2 + " file_type"))
+        self.assertFalse(self.try_command(SAMPLE_PATH_2 + "||date||2018"))
 
         main.COMMANDS_PATH = TEST_COMMANDS
         os.remove(TEST_FAIL_COMMANDS)

--- a/auto-folder-sort/tests/main_test.py
+++ b/auto-folder-sort/tests/main_test.py
@@ -44,7 +44,9 @@ class TestMain(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         with open(TEST_COMMANDS, "w") as new_commands:
-            new_commands.write(f"{SAMPLE_PATH_2} file_type\n{SAMPLE_PATH_1} date 2018")
+            new_commands.write(
+                f"{SAMPLE_PATH_2} | file_type\n{SAMPLE_PATH_1} | date | 2018"
+            )
 
         # Changes where the sample_program object will read commands from
         main.COMMANDS_PATH = TEST_COMMANDS
@@ -184,17 +186,20 @@ class TestMain(unittest.TestCase):
     def test_init(self):
 
         with open(TEST_COMMANDS, "r") as text:
-            self.test_commands = [line.split() for line in text.readlines()]
+            self.test_commands = [
+                list(map(str.strip, line.split("|"))) for line in text.readlines()
+            ]
 
         self.assertEqual(self.sample_program.commands, self.test_commands)
 
         # Commands
         main.COMMANDS_PATH = TEST_FAIL_COMMANDS
 
-        self.assertTrue(SAMPLE_PATH_2 + " date")
+        self.assertTrue(SAMPLE_PATH_2 + " | date")
         self.assertFalse(self.try_command(SAMPLE_PATH_2))
-        self.assertFalse(self.try_command(SAMPLE_PATH_2 + " date 2015 2018"))
-        self.assertFalse(self.try_command("date file_type string 2018"))
+        self.assertFalse(self.try_command(SAMPLE_PATH_2 + " | date | 2015 | 2018"))
+        self.assertFalse(self.try_command("date | file_type | string | 2018"))
+        self.assertFalse(self.try_command("date | file_type | string | 2018"))
 
         main.COMMANDS_PATH = TEST_COMMANDS
         os.remove(TEST_FAIL_COMMANDS)
@@ -209,7 +214,7 @@ class TestMain(unittest.TestCase):
 
         logger.debug(
             f"\nsample_sorter years: {self.sample_sorter.years}"
-            " \nMake sure this is the same as would used in the test_observer"
+            " \nMake sure this is the same as would be used in the test_observer"
         )
 
         self.undo_date_sort()

--- a/examples/folders_to_track.txt
+++ b/examples/folders_to_track.txt
@@ -1,2 +1,2 @@
-/home/user/Downloads/ file_type
-/home/user/Documents/ date 2015
+/home/user/Downloads/ | file_type
+/home/user/Documents/ | date | 2015


### PR DESCRIPTION
In relation to #3 , changed method of reading commands from a line to split items at a "|" symbol instead of at white spaces. Also made it so these items are stripped of leading and trailing whitespaces.

Updated readme and example to line up with changes.